### PR TITLE
fix ajax_validate

### DIFF
--- a/modules/yf_dynamic.class.php
+++ b/modules/yf_dynamic.class.php
@@ -478,7 +478,8 @@ class yf_dynamic {
 					break;
 				}
 			}
-			$is_valid = $class_validate->$rule['func']($rule['data'], array('param' => $rule['param']), array(), $error_msg);
+			$fname = (string)$rule['func'];
+			$is_valid = $class_validate->$fname($rule['data'], array('param' => $rule['param']), array(), $error_msg);
 			if (!$is_valid) {
 				if (!$error_msg) {
 					$error_msg = t('form_validate_'.$rule['func'], array('%field' => $rule['field'], '%param' => $rule['param']));


### PR DESCRIPTION
get error with php7
PHP Fatal error:  Uncaught exception 'Error' with message 'Function name
must be a string' in
/var/www/default/yf/modules/yf_dynamic.class.php:481

 Changes to be committed:
	modified:   modules/yf_dynamic.class.php